### PR TITLE
Added services to include connection to IBM Cloudant

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,6 @@ vignettes/*.pdf
 # OAuth2 token
 .httr-oauth
 
-.Rproj.user
+# Passwords
+*/*/test_auth.R
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ vignettes/*.pdf
 # Passwords
 */*/test_auth.R
 
+.Rproj.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
-.Rproj.user
+# History files
 .Rhistory
+.Rapp.history
+.Ruserdata
+
+# Session Data files
 .RData
+
+# Example code in package build process
+*-Ex.R
+
+# RStudio files
+.Rproj.user/
+*.Rproj
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token
+.httr-oauth
+

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ vignettes/*.pdf
 # OAuth2 token
 .httr-oauth
 
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,4 @@ Depends:
 Description: Interface to couchDB
 SystemRequirements: couchDB instance to connect to and work on.
 License: AGPL-3
+Suggests: testthat

--- a/R/couchDB.R
+++ b/R/couchDB.R
@@ -52,7 +52,7 @@ couch_base_url <- function(conn) {
     if (!is.null(conn$user)) {
       auth <- paste0(conn$user,":", conn$password, "@") 
     } else {
-      auth <-"" 
+      auth <- "" 
     }
     base_url <- paste0(proto, 
                        "://", 
@@ -62,7 +62,7 @@ couch_base_url <- function(conn) {
   base_url
 }
 
-couch_fetch_url <- function(conn,database,key = NULL,opts = NULL){
+couch_fetch_url <- function(conn,database,key = NULL, opts = NULL){
   url <- paste(couch_base_url(conn), database, key, sep = "/")
   url
 }
@@ -75,19 +75,22 @@ couch_fetch_url <- function(conn,database,key = NULL,opts = NULL){
 #'@param key Document key
 #'@param attachment Name of the attachment
 #'@export
-couch_fetch_attachment_url <- function(conn,database,key = NULL,attachment = NULL){
+couch_fetch_attachment_url <- function(conn, 
+                                       database, 
+                                       key = NULL, 
+                                       attachment = NULL){
   url <- paste(couch_base_url(conn), database, key,attachment, sep = "/")
   url
 }
 
 couch_store_url <- function(conn, database, key = NULL, opts = NULL) {
-  if(is.null(key)) {
+  if (is.null(key)) {
     url <- paste(couch_base_url(conn), database, sep = "/")
   } else {
     url <- paste(couch_base_url(conn), database, key, sep = "/")
     #check for revision number
     revision_number <- HEAD(url)$header$etag
-    if(!is.null(revision_number)){ 
+    if (!is.null(revision_number)){ 
       url <- paste0(url,"?rev=",gsub("\"","",revision_number))
     }
   }
@@ -128,7 +131,7 @@ couch_set_default_connection <- function(host,port = 5984, https = FALSE){
 #'@param database the database to use as default (String)
 #'@export
 couch_set_default_database <- function(database){
-  if(is.character(database)){
+  if (is.character(database)) {
     couch_default_database <<- database
   } else {
     warning("Default database could not be set.")
@@ -181,7 +184,7 @@ couch_http_connection <- function(host,
 #' @param conn a couchDB connection object
 #' @method print couch_connection
 print.couch_connection <- function(conn) {
-  if(conn$secure == TRUE) {
+  if (conn$secure == TRUE) {
     proto <- "https"
   } else {
     proto <- "http"
@@ -194,7 +197,7 @@ print.couch_connection <- function(conn) {
 
 couch_check_status <- function(conn, expected_codes, response) {
   status_code <- response$status_code
-  if(any(expected_codes == status_code)) {
+  if (any(expected_codes == status_code)) {
     response
   } else {
     # TODO - better error handling
@@ -232,7 +235,7 @@ couch_fetch_raw <- function(conn, database, key, opts = NULL) {
   expected_codes <- c(200, 300, 304)
   result <- GET(path)
   status_code <- result$status_code
-  if(any(expected_codes == status_code)) {
+  if (any(expected_codes == status_code)) {
     result
   } else {
     # TODO
@@ -250,7 +253,11 @@ couch_fetch_raw <- function(conn, database, key, opts = NULL) {
 #' @description
 #' Send attachment to an existing url
 #' @export
-couch_attach <- function(location,revtag,attachment,content_type = "image/png"){
+couch_attach <- function(location, 
+                         revtag,  
+                         attachment, 
+                         content_type = "image/png"){
+
   path <- paste0(location,"/",basename(attachment),"?rev=",revtag)
   headers <- couch_store_headers_put(content_type)
   command <- paste0('curl -vX PUT ',
@@ -270,8 +277,10 @@ couch_attach <- function(location,revtag,attachment,content_type = "image/png"){
 #'@return A list object with the values from the record.
 #'@export
 couch_fetch <- function(conn, database, key, myOpts=NULL) {
+  if (!exists("database")) {warning("you must specify a database")}
+  if (!exists("key")) {warning("you must specify a document key")}
   result <- couch_fetch_raw(conn, database, key, myOpts)
-  fromJSON(content(result, as = "parsed"))
+  content(result, as = "parsed", encoding = "UTF-8")
 }
 
 #'@title Fetch attachment 
@@ -316,8 +325,8 @@ couch_fetch_default <- function(key, myOpts = NULL){
 #' } 
 #'@export
 couch_new_object <- function(value, database = NULL, key = NULL) {
-  if (is.null(database))database <- couch_default_database
-  if(is.list(value))value<-toJSON(value)
+  if (is.null(database)) database <- couch_default_database
+  if (is.list(value)) value <- toJSON(value)
   list(value = value, database = database, key = key, content_type = "application/json")
 }
 
@@ -332,7 +341,7 @@ couch_new_object <- function(value, database = NULL, key = NULL) {
 #'    couch_create_database(myConn,"myDatabase") 
 #' } 
 #'@export
-couch_create_database<- function(conn,dbname){
+couch_create_database <- function(conn,dbname){
   path = paste0(couch_base_url(conn),"/",dbname)
   result <- PUT(path)
   result
@@ -349,10 +358,10 @@ couch_store <- function(conn, obj, myOpts = NULL) {
   expected_codes <- c(200, 201, 204, 300)
   accept_json()
   headers <- couch_store_headers_post(obj$content_type, myOpts)
-  if(is.null(obj$key)){
-    result <- POST(path, body = obj$value,add_headers(headers))
+  if (is.null(obj$key)) {
+    result <- POST(path, body = obj$value, add_headers(headers))
   } else {
-    result <- PUT(path, body = obj$value,add_headers(headers))
+    result <- PUT(path, body = obj$value, add_headers(headers))
   }
   result
 }
@@ -367,7 +376,7 @@ couch_store_default <- function(obj, myOpts = NULL) {
   expected_codes <- c(200, 201, 204, 300)
   accept_json()
   headers <- couch_store_headers_post(obj$content_type, myOpts)
-  if(is.null(obj$key)){
+  if (is.null(obj$key)) {
     result <- POST(path, body = obj$value,add_headers(headers))
   } else {
     result <- PUT(path, body = obj$value,add_headers(headers))

--- a/R/couchDB.R
+++ b/R/couchDB.R
@@ -142,8 +142,11 @@ couch_list_databases_url <- function(conn) {
 #'    myConn <- couch_http_connection(host="localhost")
 #' } 
 #' @export
-couch_http_connection <- function(host, port=5984, https=FALSE, 
-                                   user=NULL, password=NULL) {
+couch_http_connection <- function(host, 
+                                  port=5984, 
+                                  https=FALSE, 
+                                  user=NULL, 
+                                  password=NULL) {
   
   conn <- list(couch_http_host = host, 
                couch_http_port = port, 
@@ -186,10 +189,12 @@ couch_check_status <- function(conn, expected_codes, response) {
 #' @param conn A couchDB connection object.
 #' @export
 couch_ping <- function(conn) {
-  path <- couch_base_url(conn)
-  expected_codes = c(200)
-  result <- GET(path)
-  couch_check_status(conn, expected_codes, result)
+  try({
+    path <- couch_base_url(conn)
+    expected_codes = c(200)
+    result <- GET(path)
+    couch_check_status(conn, expected_codes, result)
+  })
 }
 
 # Internal use

--- a/R/couchDB.R
+++ b/R/couchDB.R
@@ -3,6 +3,7 @@ require(RCurl)
 require(httr)
 require(rjson)
 
+
 #'@import bitops
 #'@import RCurl
 #'@import httr
@@ -407,6 +408,5 @@ couch_mapreduce <- function(conn, query) {
 #'@export
 couch_list_databases <- function(conn) {
   path <- couch_list_databases_url(conn)
-  expected_codes <- c(200)
-  fromJSON(content(GET(path)))
+  unlist(content(GET(path)))
 }

--- a/R/couchDB.R
+++ b/R/couchDB.R
@@ -1,11 +1,8 @@
-####################################################################
-# Couch R Client
-# Programmer: Aleksander Dietrichson
-# Purpose: interface with couchDB
 require(bitops)
 require(RCurl)
 require(httr)
 require(rjson)
+
 #'@import bitops
 #'@import RCurl
 #'@import httr

--- a/R/couchDB.R
+++ b/R/couchDB.R
@@ -2,7 +2,6 @@
 # Couch R Client
 # Programmer: Aleksander Dietrichson
 # Purpose: interface with couchDB
-# Date: 2013-11-25
 require(bitops)
 require(RCurl)
 require(httr)
@@ -12,8 +11,8 @@ require(rjson)
 #'@import httr
 #'@import rjson
 #description formats name-value pair as url parameter
-couch_default_database=NULL;
-couch_default_connection=NULL;
+couch_default_database=NULL
+couch_default_connection=NULL
 url_param <- function(name, value) {
   if(is.null(value)) {
     NULL
@@ -39,29 +38,35 @@ couch_base_url <- function(conn) {
     proto <- "http"
   }
   if(!is.null(conn$user)){
-    auth <- paste0(conn$user,":",conn$password,"@"); 
+    auth <- paste0(conn$user,":",conn$password,"@") 
   } else {
-    auth <-""; 
+    auth <-"" 
   }
-  base_url <- paste0(proto, "://",auth, conn$couch_http_host, ":", conn$couch_http_port)
+  base_url <- paste0(proto, 
+                     "://", 
+                     auth, 
+                     conn$couch_http_host, 
+                     ":", 
+                     conn$couch_http_port)
   base_url
 }
 
 couch_fetch_url <- function(conn,database,key=NULL,opts=NULL){
-  url <- paste(couch_base_url(conn), database, key, sep="/");
-  url;
+  url <- paste(couch_base_url(conn), database, key, sep="/")
+  url
 }
 
 #'@title Get attachment url
-#'@description Get the url for a specific attachment, This is sometimes useful for direct reads to functions, in lieu of storing tempfiles.
+#'@description Get the url for a specific attachment, This is sometimes useful
+#'for direct reads to functions, in lieu of storing tempfiles.
 #'@param conn A connection object
 #'@param database The database name
 #'@param key Document key
 #'@param attachment Name of the attachment
 #'@export
 couch_fetch_attachment_url <- function(conn,database,key=NULL,attachment=NULL){
-  url <- paste(couch_base_url(conn), database, key,attachment, sep="/");
-  url;
+  url <- paste(couch_base_url(conn), database, key,attachment, sep="/")
+  url
 }
 
 couch_store_url <- function(conn, database, key=NULL, opts=NULL) {
@@ -70,16 +75,18 @@ couch_store_url <- function(conn, database, key=NULL, opts=NULL) {
   } else {
     url <- paste(couch_base_url(conn), database, key, sep="/")
     #check for revision number
-    revision_number <- HEAD(url)$header$etag;
-    if(!is.null(revision_number)) url <- paste0(url,"?rev=",gsub("\"","",revision_number));
+    revision_number <- HEAD(url)$header$etag
+    if(!is.null(revision_number)){ 
+      url <- paste0(url,"?rev=",gsub("\"","",revision_number))
+    }
   }
   url
 }
 
 couch_get_headers <- function(conn,database,key){
-  path <- couch_store_url(conn,database,key);
-  result <- HEAD(path)$headers;
-  result;
+  path <- couch_store_url(conn,database,key)
+  result <- HEAD(path)$headers
+  result
 }
 couch_delete_url <- function(conn, database, key, myOpts=NULL) {
   url <- paste("databases", database, "keys", key)
@@ -99,18 +106,21 @@ couch_mapred_url <- function(conn) {
 #' @param https Should a ssl protocol be used?
 #' @export
 couch_set_default_connection <- function(host,port=5984, https=FALSE){
-  couch_default_connection <<- couch_http_connection(host=host,port=port,https=https);
+  couch_default_connection <<- couch_http_connection(host=host,
+                                                     port=port,
+                                                     https=https)
 }
 
 #'@title Set a database as default document store
-#'@description Specifies a database to write to on a couch connection by default.
-#'@param database the database to use as default (String);
+#'@description Specifies a database to write to on a couch connection by
+#'default.
+#'@param database the database to use as default (String)
 #'@export
 couch_set_default_database <- function(database){
   if(is.character(database)){
-    couch_default_database <<- database;
+    couch_default_database <<- database
   } else {
-    warning("Default database could not be set.");
+    warning("Default database could not be set.")
   }
 }
 
@@ -132,15 +142,19 @@ couch_list_databases_url <- function(conn) {
 #' @param user Username on the database server
 #' @param password Password for the database server
 #' @examples \dontrun{ 
-#'    myConn <- couch_http_connection(host="localhost");
+#'    myConn <- couch_http_connection(host="localhost")
 #' } 
 #' @export
-couch_http_connection <- function(host, port=5984, https=FALSE, user=NULL,password=NULL) {
+couch_http_connection <- function(host, port=5984, https=FALSE, 
+                                   user=NULL, password=NULL) {
   
-  conn <- list(couch_http_host = host, couch_http_port = port, secure=https, user=user,password=password);
+  conn <- list(couch_http_host = host, 
+               couch_http_port = port, 
+               secure=https, 
+               user=user,
+               password=password)
   class(conn) <- "couch_connection"
   conn
-  
 }
 
 
@@ -156,6 +170,7 @@ print.couch_connection <- function(conn) {
   }
   p <- paste(proto, conn$couch_http_host, conn$couch_http_port, sep=",")
   url <- paste(proto, "://", conn$couch_http_host, ":", conn$couch_http_port, sep="")
+
   paste("CouchDB connection to: (", url, ")")
 }
 
@@ -182,7 +197,7 @@ couch_ping <- function(conn) {
 
 # Internal use
 couch_store_headers_put <- function(content_type, opts) {
-  c("Content-Type"=content_type);
+  c("Content-Type"=content_type)
 }
 
 # Internal use.
@@ -201,7 +216,7 @@ couch_fetch_raw <- function(conn, database, key, opts=NULL) {
     result
   } else {
     # TODO
-    warning("Error fetching value from CouchDB");
+    warning("Error fetching value from CouchDB")
     result
   }
 }
@@ -216,10 +231,13 @@ couch_fetch_raw <- function(conn, database, key, opts=NULL) {
 #' Send attachment to an existing url
 #' @export
 couch_attach <- function(location,revtag,attachment,content_type="image/png"){
-  path <- paste0(location,"/",basename(attachment),"?rev=",revtag);
+  path <- paste0(location,"/",basename(attachment),"?rev=",revtag)
   headers <- couch_store_headers_put(content_type)
-  command <- paste0('curl -vX PUT ',path,' --data-binary @',attachment, ' -H "Content-Type:',content_type,'"');
-  result <- system(command);
+  command <- paste0('curl -vX PUT ',
+                     path,' --data-binary @',
+                     attachment, ' -H "Content-Type:',
+                     content_type,'"')
+  result <- system(command)
 }
 
 
@@ -244,8 +262,8 @@ couch_fetch <- function(conn, database, key, myOpts=NULL) {
 #'@param attachment name of attachment
 #'@export
 couch_fetch_attachment <- function(conn,database,key,attachment){
-  key <- paste0(key,"/",attachment);
-  couch_fetch_raw(conn,database,key,NULL);
+  key <- paste0(key,"/",attachment)
+  couch_fetch_raw(conn,database,key,NULL)
 }
 
 #'@title Fetch document/record from default store.
@@ -255,7 +273,7 @@ couch_fetch_attachment <- function(conn,database,key,attachment){
 #'@return A list object with the values from the record.
 #'@export
 couch_fetch_default <- function(key, myOpts=NULL){
-  couch_fetch(conn=couch_default_connection,database=couch_default_database,key,myOpts);  
+  couch_fetch(conn=couch_default_connection,database=couch_default_database,key,myOpts)  
 }
 
 
@@ -270,15 +288,15 @@ couch_fetch_default <- function(key, myOpts=NULL){
 #' @examples \dontrun{ 
 #'    # This code creates a document containing a small list for storage in the "localhost" 
 #'    # database with the key "testDoc".
-#'    myDoc <- couch_new_object(list(a=1,b=2),"localhost","testDoc"); 
+#'    myDoc <- couch_new_object(list(a=1,b=2),"localhost","testDoc") 
 #'    
 #'    #Same as above but with json entered directly (not recommended).
 #'    myDoc <- couch_new_object('{"a":1,"b":2}',"localhost","testDoc")
 #' } 
 #'@export
 couch_new_object <- function(value, database=NULL, key=NULL) {
-  if (is.null(database))database <- couch_default_database;
-  if(is.list(value))value<-toJSON(value);
+  if (is.null(database))database <- couch_default_database
+  if(is.list(value))value<-toJSON(value)
   list(value=value, database=database, key=key, content_type="application/json")
 }
 
@@ -289,14 +307,14 @@ couch_new_object <- function(value, database=NULL, key=NULL) {
 #'@description Creates a new couchDB database on the connection provided.
 #' @examples \dontrun{ 
 #' #Note: this example assumes that there is a couchDB instance available on localhost
-#'    myConn <- couch_http_connection("localhost");
+#'    myConn <- couch_http_connection("localhost")
 #'    couch_create_database(myConn,"myDatabase") 
 #' } 
 #'@export
 couch_create_database<- function(conn,dbname){
-  path = paste0(couch_base_url(conn),"/",dbname);
-  result <- PUT(path);
-  result;
+  path = paste0(couch_base_url(conn),"/",dbname)
+  result <- PUT(path)
+  result
 }
 
 #'@title Store a record
@@ -307,13 +325,13 @@ couch_create_database<- function(conn,dbname){
 #'@export
 couch_store <- function(conn, obj, myOpts=NULL) { 
   path <- couch_store_url(conn, obj$database, obj$key)
-  expected_codes <- c(200, 201, 204, 300);
+  expected_codes <- c(200, 201, 204, 300)
   accept_json()
-  headers <- couch_store_headers_post(obj$content_type, myOpts);
+  headers <- couch_store_headers_post(obj$content_type, myOpts)
   if(is.null(obj$key)){
-    result <- POST(path, body=obj$value,add_headers(headers));
+    result <- POST(path, body=obj$value,add_headers(headers))
   } else {
-    result <- PUT(path, body=obj$value,add_headers(headers));
+    result <- PUT(path, body=obj$value,add_headers(headers))
   }
   result
 }
@@ -325,13 +343,13 @@ couch_store <- function(conn, obj, myOpts=NULL) {
 #'@export
 couch_store_default <- function(obj, myOpts=NULL) { 
   path <- couch_store_url(couch_default_connection, obj$database, obj$key)
-  expected_codes <- c(200, 201, 204, 300);
+  expected_codes <- c(200, 201, 204, 300)
   accept_json()
-  headers <- couch_store_headers_post(obj$content_type, myOpts);
+  headers <- couch_store_headers_post(obj$content_type, myOpts)
   if(is.null(obj$key)){
-    result <- POST(path, body=obj$value,add_headers(headers));
+    result <- POST(path, body=obj$value,add_headers(headers))
   } else {
-    result <- PUT(path, body=obj$value,add_headers(headers));
+    result <- PUT(path, body=obj$value,add_headers(headers))
   }
   result
 }
@@ -358,7 +376,7 @@ couch_mapreduce <- function(conn, query) {
   path <- couch_mapred_url(conn)
   expected_codes <- c(200)
   add_headers("ContentType: application/json")
-  result <- POST(path,body=query);
+  result <- POST(path,body=query)
   content(couch_check_status(conn, expected_codes, result))
 }
 
@@ -367,7 +385,7 @@ couch_mapreduce <- function(conn, query) {
 #'@description Lists the available databases on the connection provided.
 #'@export
 couch_list_databases <- function(conn) {
-  path <- couch_list_databases_url(conn);
-  expected_codes <- c(200);
+  path <- couch_list_databases_url(conn)
+  expected_codes <- c(200)
   fromJSON(content(GET(path)))
 }

--- a/R/couchDB.R
+++ b/R/couchDB.R
@@ -3,7 +3,6 @@ require(RCurl)
 require(httr)
 require(rjson)
 
-
 #'@import bitops
 #'@import RCurl
 #'@import httr
@@ -13,13 +12,13 @@ couch_default_database = NULL
 couch_default_connection = NULL
 
 url_param <- function(name, value) {
-  if(is.null(value)) {
+  if (is.null(value)) {
     NULL
   } else {
-    if(is.logical(value)) {
-      paste(name," = ",curlEscape(tolower(value)), sep = "")
+    if (is.logical(value)) {
+      paste(name," = ", curlEscape(tolower(value)), sep = "")
     } else {
-      paste(name," = ",curlEscape(value), sep = "")
+      paste(name," = ", curlEscape(value), sep = "")
     }
   }
 }
@@ -30,17 +29,16 @@ make_query_string <- function(params) {
 }
 
 couch_base_url <- function(conn) {
-  #TODO: update here for password authentication
-  if(conn$secure == TRUE) {
+  if (conn$secure == TRUE) {
     proto <- "https"
   } else {
     proto <- "http"
   }
-  if(conn$service == "couchdb"){
-    if(!is.null(conn$user)){
+  if (conn$service == "couchdb") {
+    if (!is.null(conn$user)) {
       auth <- paste0(conn$user,":",conn$password,"@") 
     } else {
-      auth <-"" 
+      auth <- "" 
     }
     base_url <- paste0(proto, 
                        "://", 
@@ -49,10 +47,10 @@ couch_base_url <- function(conn) {
                        ":", 
                        conn$couch_http_port)
   }
-  if(conn$service == "cloudant"){
+  if (conn$service == "cloudant") {
   # Cloudant does not accept a port number when calling the service
-    if(!is.null(conn$user)){
-      auth <- paste0(conn$user,":",conn$password,"@") 
+    if (!is.null(conn$user)) {
+      auth <- paste0(conn$user,":", conn$password, "@") 
     } else {
       auth <-"" 
     }
@@ -277,15 +275,15 @@ couch_fetch <- function(conn, database, key, myOpts=NULL) {
 }
 
 #'@title Fetch attachment 
-#'@description Gets a named attachment from a recors
+#'@description Gets a named attachment from a resource
 #'@param conn A couchDB connection object
-#'@param database The database to connecto to
+#'@param database The database to connect to
 #'@param key Key of document
 #'@param attachment name of attachment
 #'@export
 couch_fetch_attachment <- function(conn,database,key,attachment){
   key <- paste0(key,"/",attachment)
-  couch_fetch_raw(conn,database,key,NULL)
+  couch_fetch_raw(conn,database,key, NULL)
 }
 
 #'@title Fetch document/record from default store.
@@ -300,13 +298,14 @@ couch_fetch_default <- function(key, myOpts = NULL){
 
 
 #'@title New couchDB document
-#'@param value  List to be converted to json for transmission or preformatted JSON string
+#'@param value  List to be converted to json for transmission or pre-formatted
+#'JSON string
 #'@param database  The database to use
 #'@param key  The key (recordname) to use for the object.
 #'@description Creates a new object to to insert to the couchDB.
 #'Takes either a list or a formatted json object as value
-#'Any attachment to the record needs to be base64-enconded added to the list as "_attachments"
-#'If key is provided this is used, null sends a key-less record to couch and the key will have to be retrieved from the reponse object.
+#'Any attachment to the record needs to be base64-encoded added to the list as "_attachments"
+#'If key is provided this is used, null sends a key-less record to couch and the key will have to be retrieved from the response object.
 #' @examples \dontrun{ 
 #'    # This code creates a document containing a small list for storage in the "localhost" 
 #'    # database with the key "testDoc".

--- a/R/couchDB.R
+++ b/R/couchDB.R
@@ -8,23 +8,23 @@ require(rjson)
 #'@import httr
 #'@import rjson
 #description formats name-value pair as url parameter
-couch_default_database=NULL
-couch_default_connection=NULL
+couch_default_database = NULL
+couch_default_connection = NULL
 url_param <- function(name, value) {
   if(is.null(value)) {
     NULL
   } else {
     if(is.logical(value)) {
-      paste(name,"=",curlEscape(tolower(value)), sep="")
+      paste(name," = ",curlEscape(tolower(value)), sep = "")
     } else {
-      paste(name,"=",curlEscape(value), sep="")
+      paste(name," = ",curlEscape(value), sep = "")
     }
   }
 }
 
 make_query_string <- function(params) {
-  params2 <- paste(params, collapse="&")
-  paste("?", params2, sep="")
+  params2 <- paste(params, collapse = "&")
+  paste("?", params2, sep = "")
 }
 
 couch_base_url <- function(conn) {
@@ -48,8 +48,8 @@ couch_base_url <- function(conn) {
   base_url
 }
 
-couch_fetch_url <- function(conn,database,key=NULL,opts=NULL){
-  url <- paste(couch_base_url(conn), database, key, sep="/")
+couch_fetch_url <- function(conn,database,key = NULL,opts = NULL){
+  url <- paste(couch_base_url(conn), database, key, sep = "/")
   url
 }
 
@@ -61,16 +61,16 @@ couch_fetch_url <- function(conn,database,key=NULL,opts=NULL){
 #'@param key Document key
 #'@param attachment Name of the attachment
 #'@export
-couch_fetch_attachment_url <- function(conn,database,key=NULL,attachment=NULL){
-  url <- paste(couch_base_url(conn), database, key,attachment, sep="/")
+couch_fetch_attachment_url <- function(conn,database,key = NULL,attachment = NULL){
+  url <- paste(couch_base_url(conn), database, key,attachment, sep = "/")
   url
 }
 
-couch_store_url <- function(conn, database, key=NULL, opts=NULL) {
+couch_store_url <- function(conn, database, key = NULL, opts = NULL) {
   if(is.null(key)) {
-    url <- paste(couch_base_url(conn), database, sep="/")
+    url <- paste(couch_base_url(conn), database, sep = "/")
   } else {
-    url <- paste(couch_base_url(conn), database, key, sep="/")
+    url <- paste(couch_base_url(conn), database, key, sep = "/")
     #check for revision number
     revision_number <- HEAD(url)$header$etag
     if(!is.null(revision_number)){ 
@@ -85,16 +85,16 @@ couch_get_headers <- function(conn,database,key){
   result <- HEAD(path)$headers
   result
 }
-couch_delete_url <- function(conn, database, key, myOpts=NULL) {
+couch_delete_url <- function(conn, database, key, myOpts = NULL) {
   url <- paste("databases", database, "keys", key)
-  paste(url, sep="")
+  paste(url, sep = "")
 }
 couch_stats_url <- function(conn) {
-  paste(couch_base_url(conn), "/stats", sep="")
+  paste(couch_base_url(conn), "/stats", sep = "")
 }
 #TODO: update this
 couch_mapred_url <- function(conn) {
-  paste(couch_base_url(conn), "/mapred", sep="")
+  paste(couch_base_url(conn), "/mapred", sep = "")
 }
 #'@title Set default connection
 #'@description Sets up a couchDB connection to use as default
@@ -102,10 +102,10 @@ couch_mapred_url <- function(conn) {
 #' @param port The port to connect to
 #' @param https Should a ssl protocol be used?
 #' @export
-couch_set_default_connection <- function(host,port=5984, https=FALSE){
-  couch_default_connection <<- couch_http_connection(host=host,
-                                                     port=port,
-                                                     https=https)
+couch_set_default_connection <- function(host,port = 5984, https = FALSE){
+  couch_default_connection <<- couch_http_connection(host = host,
+                                                     port = port,
+                                                     https = https)
 }
 
 #'@title Set a database as default document store
@@ -126,7 +126,7 @@ couch_set_default_database <- function(database){
 #for internal use
 #param conn: A couchDB connection object.
 couch_list_databases_url <- function(conn) {
-  paste(couch_base_url(conn), "_all_dbs", sep="/")
+  paste(couch_base_url(conn), "_all_dbs", sep = "/")
 }
 
 ### operations
@@ -139,20 +139,20 @@ couch_list_databases_url <- function(conn) {
 #' @param user Username on the database server
 #' @param password Password for the database server
 #' @examples \dontrun{ 
-#'    myConn <- couch_http_connection(host="localhost")
+#'    myConn <- couch_http_connection(host = "localhost")
 #' } 
 #' @export
 couch_http_connection <- function(host, 
-                                  port=5984, 
-                                  https=FALSE, 
-                                  user=NULL, 
-                                  password=NULL) {
+                                  port = 5984, 
+                                  https = FALSE, 
+                                  user = NULL, 
+                                  password = NULL) {
   
   conn <- list(couch_http_host = host, 
                couch_http_port = port, 
-               secure=https, 
-               user=user,
-               password=password)
+               secure = https, 
+               user = user,
+               password = password)
   class(conn) <- "couch_connection"
   conn
 }
@@ -163,13 +163,13 @@ couch_http_connection <- function(host,
 #' @param conn a couchDB connection object
 #' @method print couch_connection
 print.couch_connection <- function(conn) {
-  if(conn$secure== TRUE) {
+  if(conn$secure == TRUE) {
     proto <- "https"
   } else {
     proto <- "http"
   }
-  p <- paste(proto, conn$couch_http_host, conn$couch_http_port, sep=",")
-  url <- paste(proto, "://", conn$couch_http_host, ":", conn$couch_http_port, sep="")
+  p <- paste(proto, conn$couch_http_host, conn$couch_http_port, sep = ",")
+  url <- paste(proto, "://", conn$couch_http_host, ":", conn$couch_http_port, sep = "")
 
   paste("CouchDB connection to: (", url, ")")
 }
@@ -199,17 +199,17 @@ couch_ping <- function(conn) {
 
 # Internal use
 couch_store_headers_put <- function(content_type, opts) {
-  c("Content-Type"=content_type)
+  c("Content-Type" = content_type)
 }
 
 # Internal use.
 couch_store_headers_post <- function(content_type, opts) {
-  c("Content-Type"=content_type)
+  c("Content-Type" = content_type)
 }
 
 # Couch_fetch_raw returns the entire HTTP response
 # you'll need to decode the response using content()
-couch_fetch_raw <- function(conn, database, key, opts=NULL) {
+couch_fetch_raw <- function(conn, database, key, opts = NULL) {
   path <- couch_fetch_url(conn, database, key, opts)
   expected_codes <- c(200, 300, 304)
   result <- GET(path)
@@ -232,7 +232,7 @@ couch_fetch_raw <- function(conn, database, key, opts=NULL) {
 #' @description
 #' Send attachment to an existing url
 #' @export
-couch_attach <- function(location,revtag,attachment,content_type="image/png"){
+couch_attach <- function(location,revtag,attachment,content_type = "image/png"){
   path <- paste0(location,"/",basename(attachment),"?rev=",revtag)
   headers <- couch_store_headers_put(content_type)
   command <- paste0('curl -vX PUT ',
@@ -253,7 +253,7 @@ couch_attach <- function(location,revtag,attachment,content_type="image/png"){
 #'@export
 couch_fetch <- function(conn, database, key, myOpts=NULL) {
   result <- couch_fetch_raw(conn, database, key, myOpts)
-  fromJSON(content(result, as="parsed"))
+  fromJSON(content(result, as = "parsed"))
 }
 
 #'@title Fetch attachment 
@@ -274,8 +274,8 @@ couch_fetch_attachment <- function(conn,database,key,attachment){
 #'@param myOpts Additional options (not implemented in this version) 
 #'@return A list object with the values from the record.
 #'@export
-couch_fetch_default <- function(key, myOpts=NULL){
-  couch_fetch(conn=couch_default_connection,database=couch_default_database,key,myOpts)  
+couch_fetch_default <- function(key, myOpts = NULL){
+  couch_fetch(conn = couch_default_connection,database = couch_default_database,key,myOpts)  
 }
 
 
@@ -290,16 +290,16 @@ couch_fetch_default <- function(key, myOpts=NULL){
 #' @examples \dontrun{ 
 #'    # This code creates a document containing a small list for storage in the "localhost" 
 #'    # database with the key "testDoc".
-#'    myDoc <- couch_new_object(list(a=1,b=2),"localhost","testDoc") 
+#'    myDoc <- couch_new_object(list(a = 1,b = 2),"localhost","testDoc") 
 #'    
 #'    #Same as above but with json entered directly (not recommended).
 #'    myDoc <- couch_new_object('{"a":1,"b":2}',"localhost","testDoc")
 #' } 
 #'@export
-couch_new_object <- function(value, database=NULL, key=NULL) {
+couch_new_object <- function(value, database = NULL, key = NULL) {
   if (is.null(database))database <- couch_default_database
   if(is.list(value))value<-toJSON(value)
-  list(value=value, database=database, key=key, content_type="application/json")
+  list(value = value, database = database, key = key, content_type = "application/json")
 }
 
 #'@title Create database
@@ -325,15 +325,15 @@ couch_create_database<- function(conn,dbname){
 #'@param myOpts Additional options (not implemented in this version) 
 #'@description Stores a record to the connection provided (database spec is in object )
 #'@export
-couch_store <- function(conn, obj, myOpts=NULL) { 
+couch_store <- function(conn, obj, myOpts = NULL) { 
   path <- couch_store_url(conn, obj$database, obj$key)
   expected_codes <- c(200, 201, 204, 300)
   accept_json()
   headers <- couch_store_headers_post(obj$content_type, myOpts)
   if(is.null(obj$key)){
-    result <- POST(path, body=obj$value,add_headers(headers))
+    result <- POST(path, body = obj$value,add_headers(headers))
   } else {
-    result <- PUT(path, body=obj$value,add_headers(headers))
+    result <- PUT(path, body = obj$value,add_headers(headers))
   }
   result
 }
@@ -343,15 +343,15 @@ couch_store <- function(conn, obj, myOpts=NULL) {
 #'@param myOpts Additional options (not implemented in this version) 
 #'@description Stores a record on the default connection.
 #'@export
-couch_store_default <- function(obj, myOpts=NULL) { 
+couch_store_default <- function(obj, myOpts = NULL) { 
   path <- couch_store_url(couch_default_connection, obj$database, obj$key)
   expected_codes <- c(200, 201, 204, 300)
   accept_json()
   headers <- couch_store_headers_post(obj$content_type, myOpts)
   if(is.null(obj$key)){
-    result <- POST(path, body=obj$value,add_headers(headers))
+    result <- POST(path, body = obj$value,add_headers(headers))
   } else {
-    result <- PUT(path, body=obj$value,add_headers(headers))
+    result <- PUT(path, body = obj$value,add_headers(headers))
   }
   result
 }
@@ -364,7 +364,7 @@ couch_store_default <- function(obj, myOpts=NULL) {
 #'@param key key (record) to delete
 #'@param myOpts Additional options (not implemented in this version) 
 #'@export
-couch_delete <- function(conn, database, key, myOpts=NULL) {
+couch_delete <- function(conn, database, key, myOpts = NULL) {
   path <- couch_delete_url(conn, database, key, myOpts)
   expected_codes <- c(204, 404)
   result <- DELETE(path)
@@ -378,7 +378,7 @@ couch_mapreduce <- function(conn, query) {
   path <- couch_mapred_url(conn)
   expected_codes <- c(200)
   add_headers("ContentType: application/json")
-  result <- POST(path,body=query)
+  result <- POST(path,body = query)
   content(couch_check_status(conn, expected_codes, result))
 }
 

--- a/R/documentation.R
+++ b/R/documentation.R
@@ -14,7 +14,7 @@
 #' 
 #' For convenience a default connection can also be created with \link{couch_set_default_connection} using the same parameters.
 #' 
-#' Once a connection object exists, you may want to make sure it is connecting correctly with the \link{couch_ping} function. If you are properly connected the reponse should be like:
+#' Once a connection object exists, you may want to make sure it is connecting correctly with the \link{couch_ping} function. If you are properly connected the response should be like:
 #' \preformatted{
 #' Response [http://localhost:5984]
 #' Status: 200

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RcouchDB
+# R-couchDB
 R interface to the CouchDB database
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# RcouchDB
+R interface to the CouchDB database
+
+## Description
+This package contains various functions for interacting with couchDB - a document database. 
+For more information about the couchDB database see [Apache Couchdb](http://couchdb.apache.org)
+or the implementation by IBM as [IBM Cloudant](http://cloudant.com).
+
+## Usage
+You can install the library from CRAN:
+
+    install.packages("couchDB")
+    
+If you want to use any development branch on github you can use [devtools](https://cran.r-project.org/web/packages/devtools/index.html).
+for example:
+
+    devtools::install_github("xrayresearch/RcouchDB")
+    
+### Get connected
+
+To interact with a couchDB instance you will need to create a connection object. Communication with couchDB happens over a http protocol. A minimal connection (running on the default port and no password protection) would be:
+
+    myConn <- couch_http_connection("localhost")
+
+The variable `myConn` can now be used as parameters to other functions.
+
+For convenience a default connection can also be created with couch_set_default_connection using the same parameters.
+
+Once a connection object exists, you may want to make sure it is connecting correctly with the couch_ping function. 
+If you are properly connected the reponse should be something like:
+
+```
+Response [http://localhost:5984]
+Status: 200
+Content-type: text/plain; charset=utf-8
+Size: 151 B
+{"couchdb":"Welcome","uuid":"c1a367c91517195b57ddafe788a72b75","version":"1.4.0","vendor"
+{"name":"...
+```
+
+### Databases
+
+On a couchDB install there can be several databases (i.e. namespaces). The function couch_list_databases will provide a list of available databases on the connection provided.
+
+The function `couch_create_database` will, similarly, allow you to create a new database or namespace on the couchDB instance.
+
+### Fetch, store and delete documents
+
+Once you have a connection and a database to work with you can fetch, store and delete documents by using the corresponding functions:
+
+`couch_fetch()` and `couch_fetch_default()`
+
+`couch_store()` and `couch_store_default()`
+
+`couch_delete()`
+

--- a/README.md
+++ b/README.md
@@ -8,15 +8,12 @@ Couchdb](http://couchdb.apache.org) or the implementation by IBM as [IBM
 Cloudant](http://cloudant.com).
 
 ## Usage
-You can install the library from CRAN:
+The pacakge on [CRAN](https://cran.r-project.org/web/packages/couchDB/index.html) 
+is outdated at this moment. To follow the examples below (especially the
+connection to Cloudant), please install the source code in this development branch with 
+[devtools](https://cran.r-project.org/web/packages/devtools/index.html):
 
-    install.packages("couchDB")
-    
-If you want to use any development branch on github you can use
-[devtools](https://cran.r-project.org/web/packages/devtools/index.html).  for
-example:
-
-    devtools::install_github("xrayresearch/RcouchDB")
+    devtools::install_github("FvD/RcouchDB")
     
 ### Get connected
 
@@ -42,6 +39,21 @@ Content-type: text/plain; charset=utf-8
 Size: 151 B
 {"couchdb":"Welcome","uuid":"c1a367c91517195b57ddafe788a72b75","version":"1.4.0","vendor"
 {"name":"...
+```
+
+To connect to cloudant specify the service (it defaults to couchdb) as follows:
+
+    myConn <- couch_http_connection(host = "demo.cloudant.com",
+                                    https = TRUE,
+                                    service = "cloudant")
+
+```
+Response [https://demo.cloudant.com/]
+  Date: 2016-05-13 16:50
+  Status: 200
+  Content-Type: application/json
+  Size: 64 B
+{"couchdb":"Welcome","version":"1.0.2","cloudant_build":"2580"}
 ```
 
 ### Databases

--- a/README.md
+++ b/README.md
@@ -2,32 +2,38 @@
 R interface to the CouchDB database
 
 ## Description
-This package contains various functions for interacting with couchDB - a document database. 
-For more information about the couchDB database see [Apache Couchdb](http://couchdb.apache.org)
-or the implementation by IBM as [IBM Cloudant](http://cloudant.com).
+This package contains various functions for interacting with couchDB - a
+document database.  For more information about the couchDB database see [Apache
+Couchdb](http://couchdb.apache.org) or the implementation by IBM as [IBM
+Cloudant](http://cloudant.com).
 
 ## Usage
 You can install the library from CRAN:
 
     install.packages("couchDB")
     
-If you want to use any development branch on github you can use [devtools](https://cran.r-project.org/web/packages/devtools/index.html).
-for example:
+If you want to use any development branch on github you can use
+[devtools](https://cran.r-project.org/web/packages/devtools/index.html).  for
+example:
 
     devtools::install_github("xrayresearch/RcouchDB")
     
 ### Get connected
 
-To interact with a couchDB instance you will need to create a connection object. Communication with couchDB happens over a http protocol. A minimal connection (running on the default port and no password protection) would be:
+To interact with a couchDB instance you will need to create a connection
+object. Communication with couchDB happens over a http protocol. A minimal
+connection (running on the default port and no password protection) would be:
 
     myConn <- couch_http_connection("localhost")
 
 The variable `myConn` can now be used as parameters to other functions.
 
-For convenience a default connection can also be created with couch_set_default_connection using the same parameters.
+For convenience a default connection can also be created with
+couch_set_default_connection using the same parameters.
 
-Once a connection object exists, you may want to make sure it is connecting correctly with the couch_ping function. 
-If you are properly connected the reponse should be something like:
+Once a connection object exists, you may want to make sure it is connecting
+correctly with the couch_ping function. If you are properly connected the
+reponse should be something like:
 
 ```
 Response [http://localhost:5984]
@@ -40,13 +46,17 @@ Size: 151 B
 
 ### Databases
 
-On a couchDB install there can be several databases (i.e. namespaces). The function couch_list_databases will provide a list of available databases on the connection provided.
+On a couchDB install there can be several databases (i.e. namespaces). The
+function couch_list_databases will provide a list of available databases on the
+connection provided.
 
-The function `couch_create_database` will, similarly, allow you to create a new database or namespace on the couchDB instance.
+The function `couch_create_database` will, similarly, allow you to create a new
+database or namespace on the couchDB instance.
 
 ### Fetch, store and delete documents
 
-Once you have a connection and a database to work with you can fetch, store and delete documents by using the corresponding functions:
+Once you have a connection and a database to work with you can fetch, store and
+delete documents by using the corresponding functions:
 
 `couch_fetch()` and `couch_fetch_default()`
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(couchDB)
+
+test_check("couchDB")

--- a/tests/testthat/test_cloudant.R
+++ b/tests/testthat/test_cloudant.R
@@ -1,0 +1,6 @@
+source("tests/testthat/test_auth.R")
+
+test_that("There is a correct reponse from a couchdb server", {
+ result <- couch_ping(unauthorized_conn)
+ expect_equal(result$status_code, 200)
+})


### PR DESCRIPTION
- Added `services` flag to `couch_http_connection` to connect to IBM Cloudant
  (cloudant API does not accept port numbers)
- Cleaned up code (style)
- Fixed issues with fromJSON
- Added a readme file (pointing at my branch for the moment, please change back
  if you decide to merge)
- Added initial test.
